### PR TITLE
Add LiveKit AVClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,34 @@ Caddy will take care of setting up and updating an SSL certificate automatically
 ## Setup
 1. Log in to your account on https://foundryvtt.com, go to **Purchased Licenses**, select **Linux/NodeJS** as your Operating system, and click on **Download**.
 
-2. Copy the `.zip` file over to your server using e.g. [scp](https://man.openbsd.org/scp.1) or [rsync](https://download.samba.org/pub/rsync/rsync.1) and run the following (edit the version number).
+1. Copy the `.zip` file over to your server using e.g. [scp](https://man.openbsd.org/scp.1) or [rsync](https://download.samba.org/pub/rsync/rsync.1) and run the following (edit the version number).
     ```bash
-    mkdir -p /opt/foundry/vtt /opt/foundry/data/Config
+    mkdir -p /opt/foundry/vtt /opt/foundry/data/Config /opt/livekit
     unzip FoundryVTT-xx.xxx.zip -d /opt/foundry/vtt
     ```
 
-3. Copy the contents of [options.json](foundry/data/Config/options.json) to your server and replace the two mentions of `domain.tld` with your own domain name.
+1. Copy the contents of [options.json](foundry/data/Config/options.json) to your server and replace the two mentions of `domain.tld` with your own domain name.
     ```bash
     nano /opt/foundry/data/Config/options.json
     ```
 
-4. Copy the contents from [caddy.nix](nixos-configs/caddy.nix) to your server and replace `domain.tld` with your own domain name.
+1. Copy the contents of [config.yaml](livekit/config.yaml) to your server and replace the API key and secret with your own.
+    ```bash
+    nix-shell -p livekit --command "livekit-server generate-keys" > /opt/livekit/config.yaml
+    nano /opt/livekit/config.yaml
+    ```
+
+1. Copy the contents of [caddy.nix](nixos-configs/caddy.nix) to your server and replace `domain.tld` with your own domain name.
     ```bash
     nano /etc/nixos/caddy.nix
     ```
 
-5. Copy the contents from [foundry.nix](nixos-configs/foundry.nix) to your server.
+1. Copy the contents of [foundry.nix](nixos-configs/foundry.nix) to your server.
     ```bash
     nano /etc/nixos/foundry.nix
     ```
 
-6. Add the two new `.nix` files to your `configuration.nix` file's import section.
+1. Add the two new `.nix` files to your `configuration.nix` file's import section.
     ```bash
     nano /etc/nixos/configuration.nix
     ```
@@ -42,7 +48,9 @@ Caddy will take care of setting up and updating an SSL certificate automatically
     ];
     ```
 
-7. Rebuild NixOS to enable the new  `caddy` and `foundryvtt` services and your new Foundry VTT server should now be online and accessible!
+1. Rebuild NixOS to enable the new  `caddy`, `foundryvtt`, and `livekit` services and your new Foundry VTT server should now be online and accessible!
     ```bash
     nixos-rebuild switch
     ```
+
+1. Lastly, when configuring your Foundry server, be sure to install the [LiveKit AVClient module](https://github.com/bekriebel/fvtt-module-avclient-livekit?tab=readme-ov-file#installation) and enable it to use LiveKit instead of the built-in A/V client.

--- a/nixos-configs/caddy.nix
+++ b/nixos-configs/caddy.nix
@@ -26,13 +26,22 @@
       }
 
       # Send it to the backend
-      reverse_proxy http://localhost:30000 {
-        transport http {
-          keepalive 10s
+      route /* {
+        reverse_proxy http://localhost:30000 {
+          transport http {
+            keepalive 10s
+          }
+          # Set ip for logs
+          header_up X-Real-IP {remote_host}
         }
+      }
 
-        # Set ip for logs
-        header_up X-Real-IP {remote_host}
+      route /livekit* {
+        uri strip_prefix /livekit
+        reverse_proxy http://localhost:7880 {
+          transport http {
+            keepalive 10s
+        }
       }
     '';
   };

--- a/nixos-configs/foundry.nix
+++ b/nixos-configs/foundry.nix
@@ -2,14 +2,16 @@
 {
 
   environment.systemPackages = [
+    pkgs.livekit-cli  # For interacting with LiveKit
     pkgs.unzip  # Foundry needs this to install modules
-    pkgs.nodejs_18
   ];
 
   # Open the required ports in the firewall
-  networking.firewall.allowedTCPPorts = [ 80 443 ];
+  # TCP 7880 and UDP 50000-60000 are for hosting LiveKit
+  networking.firewall.allowedTCPPorts = [ 80 443 7880 ];
+  networking.firewall.allowedUDPPortRanges = [ { from = 50000; to = 60000; } ];
 
-  # The service below expects to find the Foundry VTT files in /opt/foundry/vtt
+  # The foundryvtt service expects to find the Foundry VTT files in /opt/foundry/vtt
   # and the data files in /opt/foundry/data
   systemd.services.foundryvtt = {
     description = "Foundry Virtual Tabletop";
@@ -22,5 +24,18 @@
     wantedBy = [ "multi-user.target" ];
   };
   systemd.services.foundryvtt.enable = true;
+
+  # The livekit service expects to find the config.yaml file in /opt/livekit
+  systemd.services.livekit = {
+    description = "LiveKit server for handling A/V in Foundry";
+    serviceConfig = {
+      Type = "simple";
+      RuntimeDirectory = "/opt/livekit";
+      ExecStart = "${pkgs.livekit}/bin/livekit-server --config /opt/livekit/config.yaml";
+      Restart = "always";
+    };
+    wantedBy = [ "multi-user.target" ];
+  };
+  systemd.services.livekit.enable = true;
 
 }


### PR DESCRIPTION
Add the necessary settings and instructions for installing
LiveKit AVClient to replace Foundry's built-in SimplePeer / EasyRTC A/V client.